### PR TITLE
Display fixes for Zephyr 3.2/LVGL 8

### DIFF
--- a/boards/arm/zaphod/Kconfig
+++ b/boards/arm/zaphod/Kconfig
@@ -11,8 +11,8 @@ if ZMK_DISPLAY
 menuconfig ZAPHOD_BONGO_CAT
     bool "Show WPM bongo cat"
     select ZMK_WPM
-    select LVGL_USE_IMG
-    select LVGL_USE_ANIMATION
+    select LV_USE_IMG
+    select LV_USE_ANIMATION
 
 if ZAPHOD_BONGO_CAT
 

--- a/boards/arm/zaphod/zaphod_bongo_cat_widget.c
+++ b/boards/arm/zaphod/zaphod_bongo_cat_widget.c
@@ -7,7 +7,7 @@
 #include <zmk/event_manager.h>
 #include <zmk/events/wpm_state_changed.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include "zaphod_bongo_cat_widget.h"
@@ -48,7 +48,7 @@ const void* fast_images[] = {
 	&fast_img2,
 };
 
-void set_img_src(void *var, lv_anim_value_t val) {
+void set_img_src(void *var, int32_t val) {
     lv_obj_t *img = (lv_obj_t *)var;
     lv_img_set_src(img, images[val]);
 }
@@ -95,10 +95,10 @@ void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
 }
 
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
-    widget->obj = lv_img_create(parent, NULL);
+    widget->obj = lv_img_create(parent);
     
 
-    lv_img_set_auto_size(widget->obj, true);
+    lv_obj_set_size(widget->obj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
     state_widget_wpm(widget, 0);
 
     sys_slist_append(&widgets, &widget->node);

--- a/boards/arm/zaphod/zaphod_bongo_cat_widget.h
+++ b/boards/arm/zaphod/zaphod_bongo_cat_widget.h
@@ -6,7 +6,7 @@
 
 
 #include <lvgl.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 struct zaphod_bongo_cat_widget {
     sys_snode_t node;

--- a/boards/arm/zaphod/zaphod_status_screen.c
+++ b/boards/arm/zaphod/zaphod_status_screen.c
@@ -78,7 +78,11 @@ lv_obj_t *zmk_display_status_screen() {
 
     panic_label = lv_label_create(center_frame);
     lv_label_set_text(panic_label, "Panic");
+
+    lv_obj_update_layout(dont_label); // otherwise proper height is not known
+    lv_obj_set_y(panic_label, lv_obj_get_height(dont_label));
 #endif // IS_ENABLED(CONFIG_ZAPHOD_BONGO_CAT)
+    lv_obj_set_size(center_frame, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 
 #if IS_ENABLED(CONFIG_ZMK_WIDGET_LAYER_STATUS)
     zmk_widget_layer_status_init(&layer_status_widget, screen);


### PR DESCRIPTION
Bongo cat has not been ported yet, and the size of the center widget containing "Don't Panic" was much too small.
As this is my first encounter with bongo cat, I cannot tell whether it behaves properly.