### PR TITLE
Convert zaphod-config to a module.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,58 +1,6 @@
-on: [push, pull_request, create, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
-name: Build
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container:
-      image: zmkfirmware/zmk-build-arm:stable
-    name: Build Test
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: config/
-      - name: Cache west modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-zephyr-modules
-        with:
-          path: |
-            modules/
-            tools/
-            zephyr/
-            bootloader/
-            zmk/
-          key: ${{ runner.os }}-build-v2-${{ env.cache-name }}-${{ hashFiles('manifest-dir/west.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Initialize workspace (west init)
-        run: west init -l config
-      - name: Update modules (west update)
-        run: west update
-      - name: Export zephyr CMake package (west zephyr-export)
-        run: west zephyr-export
-      - name: List modules (west list)
-        run: west list
-      - name: Build Zaphod (west build)
-        run: west build -s zmk/app -b zaphod -d build/zaphod -- -DZMK_CONFIG="${GITHUB_WORKSPACE}/config"
-      - name: Build Zaphod Lite w/ Seeeduino XIAO (west build)
-        run: west build -s zmk/app -b seeeduino_xiao -d build/zaphod_lite_xiao -- -DZMK_CONFIG="${GITHUB_WORKSPACE}/config" -DSHIELD=zaphod_lite
-      - name: Build Zaphod Lite w/ Seeeduino XIAO BLE (west build)
-        run: west build -s zmk/app -b seeeduino_xiao_ble -d build/zaphod_lite_xiao_ble -- -DZMK_CONFIG="${GITHUB_WORKSPACE}/config" -DSHIELD=zaphod_lite
-      - name: Zaphod .config
-        if: ${{ always() }}
-        run: cat -n build/zaphod/zephyr/.config
-      - name: Rename zmk.uf2
-        run: |
-          cp build/zaphod/zephyr/zmk.uf2 zaphod.uf2
-          cp build/zaphod_lite_xiao/zephyr/zmk.uf2 seeeduino_xiao_zaphod_lite.uf2
-          cp build/zaphod_lite_xiao_ble/zephyr/zmk.uf2 seeeduino_xiao_ble_zaphod_lite.uf2
-      - name: Archive
-        uses: actions/upload-artifact@v2
-        with:
-          name: firmware
-          path: '*.uf2'
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+Zaphod and Zaphod Lite ZMK Config
+=================================
+
+This configuration may be used independently as a ZMK config as
+described in https://zmk.dev/docs/development/build-flash#building-from-zmk-config-folder
+or it can be included as a module.
+
+Using This Config as a Module
+-----------------------------
+
+Add this repository to your `config/west.yml` in the `remotes` and
+`projects` sections, adding the following snippets alongside the
+entries that are already there.
+
+```yaml
+  remotes:
+    - name: zaphod
+      url-base: https://github.com/petejohanson
+  projects:
+    - name: zaphod-config
+      remote: zaphod
+      revision: main
+```

--- a/boards/shields/zaphod_lite/Kconfig
+++ b/boards/shields/zaphod_lite/Kconfig
@@ -5,8 +5,8 @@ if ZMK_DISPLAY
 menuconfig ZAPHOD_BONGO_CAT
     bool "Show WPM bongo cat"
     select ZMK_WPM
-    select LVGL_USE_IMG
-    select LVGL_USE_ANIMATION
+    select LV_USE_IMG
+    select LV_USE_ANIMATION
 
 if ZAPHOD_BONGO_CAT
 
@@ -20,5 +20,4 @@ config ZAPHOD_BONGO_CAT_SLOW_LIMIT
 
 endif # ZAPHOD_BONGO_CAT
 
-
-endif
+endif # ZMK_DISPLAY

--- a/boards/shields/zaphod_lite/Kconfig.shield
+++ b/boards/shields/zaphod_lite/Kconfig.shield
@@ -4,3 +4,24 @@
 config SHIELD_ZAPHOD_LITE
    def_bool $(shields_list_contains,zaphod_lite)
 
+if ZMK_DISPLAY
+
+menuconfig ZAPHOD_BONGO_CAT
+    bool "Show WPM bongo cat"
+    select ZMK_WPM
+    select LV_USE_IMG
+    select LV_USE_ANIMATION
+
+if ZAPHOD_BONGO_CAT
+
+config ZAPHOD_BONGO_CAT_IDLE_LIMIT
+    int "Upper limit for WPM for showing idle animation"
+    default 30
+
+config ZAPHOD_BONGO_CAT_SLOW_LIMIT
+    int "Upper limit for WPM for showing slow typing image"
+    default 60
+
+endif # ZAPHOD_BONGO_CAT
+
+endif # ZMK_DISPLAY

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.c
@@ -7,7 +7,7 @@
 #include <zmk/event_manager.h>
 #include <zmk/events/wpm_state_changed.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
 #include "zaphod_bongo_cat_widget.h"
@@ -48,7 +48,7 @@ const void* fast_images[] = {
 	&fast_img2,
 };
 
-void set_img_src(void *var, lv_anim_value_t val) {
+void set_img_src(void *var, int32_t val) {
     lv_obj_t *img = (lv_obj_t *)var;
     lv_img_set_src(img, images[val]);
 }
@@ -95,10 +95,10 @@ void state_widget_wpm(struct zaphod_bongo_cat_widget *widget, int wpm) {
 }
 
 int zaphod_bongo_cat_widget_init(struct zaphod_bongo_cat_widget *widget, lv_obj_t *parent) {
-    widget->obj = lv_img_create(parent, NULL);
-    
+    widget->obj = lv_img_create(parent);
 
-    lv_img_set_auto_size(widget->obj, true);
+    lv_obj_set_width(widget->obj, LV_SIZE_CONTENT);
+    lv_obj_set_height(widget->obj, LV_SIZE_CONTENT);
     state_widget_wpm(widget, 0);
 
     sys_slist_append(&widgets, &widget->node);

--- a/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.h
+++ b/boards/shields/zaphod_lite/zaphod_bongo_cat_widget.h
@@ -6,7 +6,7 @@
 
 
 #include <lvgl.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 struct zaphod_bongo_cat_widget {
     sys_snode_t node;

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,5 +1,5 @@
 ---
-name: zephyr-config
+name: zaphod-config
 build:
   settings:
     board_root: .

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+---
+name: zephyr-config

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,2 +1,5 @@
 ---
 name: zephyr-config
+build:
+  settings:
+    board_root: .


### PR DESCRIPTION
Adds a `zephyr/module.yml` file to zaphod-config so that other zmk-config repos can reference it as a Zephyr module.